### PR TITLE
Fix memory leak

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-    _ "net/http/pprof"
 )
 
 const version string = "1.4.0"

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+    _ "net/http/pprof"
 )
 
 const version string = "1.4.0"

--- a/nat/parser.go
+++ b/nat/parser.go
@@ -34,6 +34,7 @@ func ParseStatistics(sshCtx *connector.SSHCommandContext, pools chan *Pool, stat
 
     interfaceState := ""
 
+    Outer:
 	for {
 		select {
 		case <-sshCtx.Done:
@@ -41,7 +42,7 @@ func ParseStatistics(sshCtx *connector.SSHCommandContext, pools chan *Pool, stat
 				pools <- current
 			}
 			statistics <- statistic
-            break
+            break Outer
 		case line := <-sshCtx.Output:
 			if matches := totalActiveTranslationsRegexp.FindStringSubmatch(line); matches != nil {
 				statistic.ActiveTranslations = util.Str2float64(matches[1])

--- a/nat/parser.go
+++ b/nat/parser.go
@@ -7,32 +7,32 @@ import (
 	"strings"
 )
 
+var (
+	totalActiveTranslationsRegexp *regexp.Regexp = regexp.MustCompile(`Total active translations:\s+(\d+)\s+\((\d+)\s+static,\s+(\d+)\s+dynamic;`)
+	outsideInterfacesRegexp                     = regexp.MustCompile(`Outside interfaces:`)
+	insideInterfacesRegexp                      = regexp.MustCompile(`Inside interfaces:`)
+	interfaceRegexp                             = regexp.MustCompile(`^  (\S.*)`)
+	hitsMissesRegexp                            = regexp.MustCompile(`Hits: (\d+)\s+Misses: (\d+)`)
+	expiredTranslationsRegexp                   = regexp.MustCompile(`Expired translations: (\d+)`)
+	poolRegexp                                  = regexp.MustCompile(`\[Id: (\d+)\] access-list (\S+) pool (\S+) refcount (\d+)`)
+	netmaskRegexp                               = regexp.MustCompile(`pool (\S+): id (\d+), netmask (\S+)`)
+	ipRegexp                                    = regexp.MustCompile(`start (\S+) end (\S+)`)
+	poolTypeEtcRegexp                           = regexp.MustCompile(`type (\S+), total addresses (\d+), .*misses (\d+)`)
+	limitsRegexp                                = regexp.MustCompile(`max allowed (\d+), used (\d+), missed (\d+)`)
+	dropsRegexp                                 = regexp.MustCompile(`In-to-out drops: (\d+)  Out-to-in drops: (\d+)`)
+	drops1Regexp                                = regexp.MustCompile(`Pool stats drop: (\d+)  Mapping stats drop: (\d+)`)
+	portBlockAllocFailRegexp                    = regexp.MustCompile(`Port block alloc fail: (\d+)`)
+	ipAliasAddFailRegexp                        = regexp.MustCompile(`IP alias add fail: (\d+)`)
+	limitEntryAddFailRegexp                     = regexp.MustCompile(`Limit entry add fail: (\d+)`)
+
+)
+
 // ParseStatistics parses the cli outputs of `show ip nat statistics`
 func ParseStatistics(sshCtx *connector.SSHCommandContext, pools chan *Pool, statistics chan *Statistics) {
 	statistic := NewStatistics()
 	current := &Pool{}
 
-	defer func() {
-		statistics <- statistic
-	}()
-
-	totalActiveTranslationsRegexp := regexp.MustCompile(`Total active translations:\s+(\d+)\s+\((\d+)\s+static,\s+(\d+)\s+dynamic;`)
-	outsideInterfacesRegexp := regexp.MustCompile(`Outside interfaces:`)
-	insideInterfacesRegexp := regexp.MustCompile(`Inside interfaces:`)
-	interfaceRegexp := regexp.MustCompile(`^  (\S.*)`)
-	interfaceState := ""
-	hitsMissesRegexp := regexp.MustCompile(`Hits: (\d+)\s+Misses: (\d+)`)
-	expiredTranslationsRegexp := regexp.MustCompile(`Expired translations: (\d+)`)
-	poolRegexp := regexp.MustCompile(`\[Id: (\d+)\] access-list (\S+) pool (\S+) refcount (\d+)`)
-	netmaskRegexp := regexp.MustCompile(`pool (\S+): id (\d+), netmask (\S+)`)
-	ipRegexp := regexp.MustCompile(`start (\S+) end (\S+)`)
-	poolTypeEtcRegexp := regexp.MustCompile(`type (\S+), total addresses (\d+), .*misses (\d+)`)
-	limitsRegexp := regexp.MustCompile(`max allowed (\d+), used (\d+), missed (\d+)`)
-	dropsRegexp := regexp.MustCompile(`In-to-out drops: (\d+)  Out-to-in drops: (\d+)`)
-	drops1Regexp := regexp.MustCompile(`Pool stats drop: (\d+)  Mapping stats drop: (\d+)`)
-	portBlockAllocFailRegexp := regexp.MustCompile(`Port block alloc fail: (\d+)`)
-	ipAliasAddFailRegexp := regexp.MustCompile(`IP alias add fail: (\d+)`)
-	limitEntryAddFailRegexp := regexp.MustCompile(`Limit entry add fail: (\d+)`)
+    interfaceState := ""
 
 	for {
 		select {
@@ -41,6 +41,7 @@ func ParseStatistics(sshCtx *connector.SSHCommandContext, pools chan *Pool, stat
 				pools <- current
 			}
 			statistics <- statistic
+            break
 		case line := <-sshCtx.Output:
 			if matches := totalActiveTranslationsRegexp.FindStringSubmatch(line); matches != nil {
 				statistic.ActiveTranslations = util.Str2float64(matches[1])

--- a/nat/parser.go
+++ b/nat/parser.go
@@ -32,9 +32,9 @@ func ParseStatistics(sshCtx *connector.SSHCommandContext, pools chan *Pool, stat
 	statistic := NewStatistics()
 	current := &Pool{}
 
-    interfaceState := ""
+	interfaceState := ""
 
-    Outer:
+	Outer:
 	for {
 		select {
 		case <-sshCtx.Done:
@@ -42,7 +42,7 @@ func ParseStatistics(sshCtx *connector.SSHCommandContext, pools chan *Pool, stat
 				pools <- current
 			}
 			statistics <- statistic
-            break Outer
+			break Outer
 		case line := <-sshCtx.Output:
 			if matches := totalActiveTranslationsRegexp.FindStringSubmatch(line); matches != nil {
 				statistic.ActiveTranslations = util.Str2float64(matches[1])


### PR DESCRIPTION
Encountered memory leak in parser of the NAT collector.

Caused by an infinite loop for every new NAT scrape, that additionally build and holds a new set of static regex parsers.

Now moved static regex parsers to globals and add a break for the parsing loop.

Fixes #6