### PR TITLE
Add regexes for interface selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ devices:
       - 100
     interfaces:  # optional: Some devices (BNGs) might have thousands of interfaces
       - HundredGigE0/0/0  # you can specify the interfaces to be scraped
-      - GigabitEthernet0
+      - GigabitEthernet.* # all interfaces are interpreted as regexes, that must match the whole interface name
+    excluded_interfaces: # optional: to easy limit to broad interface regexes
+      - GigabitEthernet0/1 # entries are also regexes thet must match full interface names 
     username: monitoring  # required: Username to use for SSH auth
     key_file: /path/to/a/private.key  # optional: Private key to use for SSH auth
     password: correcthorsebatterystaple  # optional: Password for SSH auth

--- a/config/config.go
+++ b/config/config.go
@@ -78,15 +78,24 @@ func normalizeRegex(str string) string {
 	return "^" + strings.TrimRight(strings.TrimLeft(str, "^"), "$") + "$"
 }
 
-func (dgc *DeviceGroupConfig) createInterfaceRegexp() {
+func (dgc *DeviceGroupConfig) createInterfaceRegexp() error {
 	dgc.InterfacesRegexp = make([]*regexp.Regexp, len(dgc.Interfaces))
 	for i, str := range dgc.Interfaces {
-		dgc.InterfacesRegexp[i] = regexp.MustCompile(normalizeRegex(str))
+		rgx, err := regexp.Compile(normalizeRegex(str))
+		if err != nil {
+			return err
+		}
+		dgc.InterfacesRegexp[i] = rgx
 	}
 	dgc.ExcludedInterfacesRegexp = make([]*regexp.Regexp, len(dgc.ExcludedInterfaces))
 	for i, str := range dgc.ExcludedInterfaces {
-		dgc.ExcludedInterfacesRegexp[i] = regexp.MustCompile(normalizeRegex(str))
+		rgx, err := regexp.Compile(normalizeRegex(str))
+		if err != nil {
+			return err
+		}
+		dgc.ExcludedInterfacesRegexp[i] = rgx
 	}
+	return nil
 }
 
 func (dgc *DeviceGroupConfig) MatchInterface(ifName string) bool {
@@ -155,7 +164,11 @@ func Load(reader io.Reader) (*Config, error) {
 
 	for matchStr, groupConfig := range config.DeviceGroups {
 
-		groupConfig.Matcher = glob.MustCompile(matchStr)
+		rgx, err := glob.Compile(matchStr)
+		if err != nil {
+			return nil, err
+		}
+		groupConfig.Matcher = rgx
 
 		// A glob is static, if there are no special meta signs to quote.
 		// Therefore, QuoteMeta should be a no op for static strings.
@@ -174,7 +187,10 @@ func Load(reader io.Reader) (*Config, error) {
 			groupConfig.Port = defaultPort
 		}
 
-		groupConfig.createInterfaceRegexp()
+		err = groupConfig.createInterfaceRegexp()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return config, nil

--- a/config/config.go
+++ b/config/config.go
@@ -68,9 +68,9 @@ type DeviceGroupConfig struct {
 	CommandTimeout           int              `yaml:"command_timeout,omitempty"`
 	EnabledCollectors        []string         `yaml:"enabled_collectors,flow"`
 	Interfaces               []string         `yaml:"interfaces,flow"`
-	interfacesRegexp         []*regexp.Regexp `yaml:"-"`
+	InterfacesRegexp         []*regexp.Regexp `yaml:"-"`
 	ExcludedInterfaces       []string         `yaml:"excluded_interfaces,flow"`
-	excludedInterfacesRegexp []*regexp.Regexp `yaml:"-"`
+	ExcludedInterfacesRegexp []*regexp.Regexp `yaml:"-"`
 	EnabledVLANs             []string         `yaml:"enabled_vlans,flow"`
 }
 
@@ -79,25 +79,25 @@ func normalizeRegex(str string) string {
 }
 
 func (dgc *DeviceGroupConfig) createInterfaceRegexp() {
-	dgc.interfacesRegexp = make([]*regexp.Regexp, len(dgc.Interfaces))
+	dgc.InterfacesRegexp = make([]*regexp.Regexp, len(dgc.Interfaces))
 	for i, str := range dgc.Interfaces {
-		dgc.interfacesRegexp[i] = regexp.MustCompile(normalizeRegex(str))
+		dgc.InterfacesRegexp[i] = regexp.MustCompile(normalizeRegex(str))
 	}
-	dgc.excludedInterfacesRegexp = make([]*regexp.Regexp, len(dgc.ExcludedInterfaces))
+	dgc.ExcludedInterfacesRegexp = make([]*regexp.Regexp, len(dgc.ExcludedInterfaces))
 	for i, str := range dgc.ExcludedInterfaces {
-		dgc.excludedInterfacesRegexp[i] = regexp.MustCompile(normalizeRegex(str))
+		dgc.ExcludedInterfacesRegexp[i] = regexp.MustCompile(normalizeRegex(str))
 	}
 }
 
 func (dgc *DeviceGroupConfig) MatchInterface(ifName string) bool {
 	match := false
-	for _, r := range dgc.interfacesRegexp {
+	for _, r := range dgc.InterfacesRegexp {
 		if r.MatchString(ifName) {
 			match = true
 			break
 		}
 	}
-	for _, r := range dgc.excludedInterfacesRegexp {
+	for _, r := range dgc.ExcludedInterfacesRegexp {
 		if r.MatchString(ifName) {
 			match = false
 			break

--- a/interfaces/collector.go
+++ b/interfaces/collector.go
@@ -53,6 +53,7 @@ func init() {
 	operStatusDesc = prometheus.NewDesc(prefix+"up_info", "Interface operational status", l, nil)
 	errorStatusDesc = prometheus.NewDesc(prefix+"error_status_info", "Admin and operational status differ", l, nil)
 
+	// Regex expression to match the interface name, for example `GigabitEthernet0/5` or a variation of such in the interface summary
 	interfaceLineRegexp = regexp.MustCompile(`^\s*\*?\s(\S+)[\s\d-]*$`)
 }
 


### PR DESCRIPTION
Interprets all interface selection as regexes. Every regex needs to match against the whole interface name and not just a part of it.

For easy limiting of to broad inclusion regexes there is a new config option called `excluded_interfaces` to exclude specific interfaces. This are also interpreted as regexes that need to match the whole interface name.

Fixes #8